### PR TITLE
Update termbox dependency for fix CI fail.

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -7,6 +7,6 @@
   "copyright": "Copyright (C) 2016, alphaKAI",
   "license": "MIT",
   "dependencies":{
-    "termbox":"*"
+    "termbox":"~master"
   }
 }

--- a/dub.selections.json
+++ b/dub.selections.json
@@ -1,6 +1,6 @@
 {
 	"fileVersion": 1,
 	"versions": {
-		"termbox": "0.0.5"
+		"termbox": "~master"
 	}
 }


### PR DESCRIPTION
This caused bash's POSIX-compliant mode.
